### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Idea is to have kind of "immutable" devbox, where all user needs to do is to kic
 
 Ideally this would not only setup the environment and tools but also would download all necessary sources locally to get started immediately with development (e.g. with Github/VSTS PATs or some other tokens) and would setup Git and version control, all work items tracking etc. so that user doesn't have to do anything but to jump in and start coding.
 
-Also there could be some kind of options as I personnally work with different teams so the tooling might be a bit different depending on project that I'm working. Also, the built devbox should conform to the workflow I'm using - github, vsts or some local version control
+Also there could be some kind of options as I personally work with different teams so the tooling might be a bit different depending on project that I'm working. Also, the built devbox should conform to the workflow I'm using - github, vsts or some local version control
 
 Preliminary runs take about 16 minutes to create simple VM and install some basic tools like 7zip, Chrome and Firefox. I'll update on this once I get more stuff installed and set up.
 


### PR DESCRIPTION
## Summary
- fix spelling of "personally" in README

## Testing
- `grep -n personally -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68403d3b70d8832bb9651362e622101e